### PR TITLE
always apply default parameters

### DIFF
--- a/commons/src/main/java/org/apache/aurora/common/args/parsers/MultimapParser.java
+++ b/commons/src/main/java/org/apache/aurora/common/args/parsers/MultimapParser.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class MultimapParser extends TypeParameterizedParser<Multimap<?, ?>> {
 
   private static final Splitter KEY_VALUE_SPLITTER =
-      Splitter.on("=").trimResults().omitEmptyStrings();
+      Splitter.on("=").limit(2).trimResults().omitEmptyStrings(); // TODO add test and push the fix to upstream
 
   public MultimapParser() {
     super(2);

--- a/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
@@ -284,16 +284,13 @@ public class ConfigurationManager {
         if (!containerConfig.getDocker().isSetImage()) {
           throw new TaskDescriptionException("A container must specify an image.");
         }
-        if (containerConfig.getDocker().getParameters().isEmpty()) {
-          for (Map.Entry<String, String> e : settings.defaultDockerParameters.entries()) {
-            builder.getContainer().getDocker().addToParameters(
-                new DockerParameter(e.getKey(), e.getValue()));
-          }
-        } else {
-          if (!settings.allowDockerParameters) {
-            throw new TaskDescriptionException(NO_DOCKER_PARAMETERS);
-          }
-        }
+		for (Map.Entry<String, String> e : settings.defaultDockerParameters.entries()) {
+		  builder.getContainer().getDocker().addToParameters(
+			  new DockerParameter(e.getKey(), e.getValue()));
+		}
+		if (!settings.allowDockerParameters) {
+		  throw new TaskDescriptionException(NO_DOCKER_PARAMETERS);
+		}
 
         if (settings.requireDockerUseExecutor && !config.isSetExecutorConfig()) {
           throw new TaskDescriptionException(EXECUTOR_REQUIRED_WITH_DOCKER);


### PR DESCRIPTION
Allow to apply -default_docker_parameters regardless the number of job parameters. Also fixes a parsing issue for parameters like `--label=foo=bar`