### PR TITLE
Allow a job to run anywhere by specifying */*

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/filter/ConstraintMatcher.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/ConstraintMatcher.java
@@ -28,6 +28,8 @@ import org.apache.aurora.scheduler.storage.entities.IAttribute;
 import org.apache.aurora.scheduler.storage.entities.IConstraint;
 import org.apache.aurora.scheduler.storage.entities.ITaskConstraint;
 
+import static org.apache.aurora.scheduler.configuration.ConfigurationManager.DEDICATED_ATTRIBUTE;
+
 /**
  * Filter that determines whether a task's constraints are satisfied.
  */
@@ -50,6 +52,11 @@ final class ConstraintMatcher {
       AttributeAggregate cachedjobState,
       Iterable<IAttribute> hostAttributes,
       IConstraint constraint) {
+
+    // If we have specified { dedicated: */* } then the dedicated attribute should not be considered
+    if (constraint.getName().equals(DEDICATED_ATTRIBUTE) && constraint.getConstraint().getValue().getValues().contains("*/*")) {
+      return Optional.absent();
+    }
 
     Iterable<IAttribute> sameNameAttributes =
         Iterables.filter(hostAttributes, new NameFilter(constraint.getName()));

--- a/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
@@ -95,11 +95,6 @@ public class SchedulingFilterImpl implements SchedulingFilter {
     for (IConstraint constraint : VALUES_FIRST.sortedCopy(taskConstraints)) {
       Optional<Veto> veto = ConstraintMatcher.getVeto(jobState, offerAttributes, constraint);
       if (veto.isPresent()) {
-        // If we have specified { dedicated: */* } then it is a green light to run anywhere
-        // Only check if veto'd which shouldn't hurt scheduling time too much
-        if (constraint.getName().equals(DEDICATED_ATTRIBUTE) && constraint.getConstraint().getValue().getValues().contains("*/*")) {
-          continue;
-        }
         // Break early to avoid potentially-expensive operations to satisfy other constraints.
         return veto;
       }

--- a/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
@@ -95,6 +95,11 @@ public class SchedulingFilterImpl implements SchedulingFilter {
     for (IConstraint constraint : VALUES_FIRST.sortedCopy(taskConstraints)) {
       Optional<Veto> veto = ConstraintMatcher.getVeto(jobState, offerAttributes, constraint);
       if (veto.isPresent()) {
+        // If we have specified { dedicated: */* } then it is a green light to run anywhere
+        // Only check if veto'd which shouldn't hurt scheduling time too much
+        if (constraint.getName().equals(DEDICATED_ATTRIBUTE) && constraint.getConstraint().getValue().getValues().contains("*/*")) {
+          continue;
+        }
         // Break early to avoid potentially-expensive operations to satisfy other constraints.
         return veto;
       }

--- a/src/test/java/org/apache/aurora/scheduler/filter/SchedulingFilterImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/filter/SchedulingFilterImplTest.java
@@ -271,6 +271,15 @@ public class SchedulingFilterImplTest extends EasyMockTest {
   }
 
   @Test
+  public void testIgnoreDedicated() {
+    control.replay();
+
+    assertNoVetoes(
+            makeTask(JOB_A, makeConstraint(DEDICATED_ATTRIBUTE, "*/*")),
+            hostAttributes(HOST_A, dedicated(HOST_A)));
+  }
+
+  @Test
   public void testUnderLimitNoTasks() {
     control.replay();
 


### PR DESCRIPTION
The use case is that sometimes we want a job to run anywhere regardless of dedicated flags. For example:

Want to run a snapshot-service in each AZ utilizing the limit constraints. However, we don't care if it's a controller or a regular node.

The use of the dedicated flag is intentional due to the way that Aurora checks for Vetos. Also, I felt like */* was fairly straightforward in terms of matching all roles and labels

Thoughts?